### PR TITLE
Check spacy v3 installation and requirements

### DIFF
--- a/v3/requirements.txt
+++ b/v3/requirements.txt
@@ -1,5 +1,6 @@
 streamlit>=1.28.0
 spacy>=3.7.0
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 scikit-learn>=1.3.0
 textstat>=0.7.3
 numpy>=1.24.0


### PR DESCRIPTION
Add spaCy English language model to `v3/requirements.txt` to resolve "spaCy English model not found" error in the Streamlit Cloud app.

---
<a href="https://cursor.com/background-agent?bcId=bc-6565d39a-73b8-4876-a9bf-6cdbd2ea4d38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6565d39a-73b8-4876-a9bf-6cdbd2ea4d38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

