### PR TITLE
Score resort description in v3 app.py

### DIFF
--- a/v3/app.py
+++ b/v3/app.py
@@ -152,6 +152,7 @@ def main():
     .hl-TooLong {
         background: rgba(239, 68, 68, 0.12);
         border-radius: 2px;
+        border: 2px dotted rgba(239, 68, 68, 0.8);
     }
     .hl-TooComplex {
         border-left: 3px solid rgba(236, 72, 153, 0.6);

--- a/v3/app.py
+++ b/v3/app.py
@@ -152,7 +152,8 @@ def main():
     .hl-TooLong {
         background: rgba(239, 68, 68, 0.12);
         border-radius: 2px;
-        border: 2px dotted rgba(239, 68, 68, 0.8);
+        outline: 2px dotted rgba(239, 68, 68, 0.8);
+        outline-offset: 2px; /* keep clear of stacked underline box-shadows */
     }
     .hl-TooComplex {
         border-left: 3px solid rgba(236, 72, 153, 0.6);


### PR DESCRIPTION
Add a dotted border to `.hl-TooLong` in `v3/app.py` to visually distinguish "too long" passages.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3468e5d-8d6b-460f-9163-8359c43d019f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f3468e5d-8d6b-460f-9163-8359c43d019f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

